### PR TITLE
add back in tracking script

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,7 +10,8 @@ Vue.config.productionTip = false
 
 if (window._railsEnv === 'production') {
   Vue.use(VueAnalytics, {
-    id: 'UA-129227134-1'
+    id: 'UA-129227134-1',
+    checkDuplicatedScript: true
   })
 }
 Vue.use(TurbolinksAdapter)

--- a/app/views/partials/_google_analytics.html.erb
+++ b/app/views/partials/_google_analytics.html.erb
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-129227134-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-129227134-1');
+</script>

--- a/app/views/partials/_head.html.erb
+++ b/app/views/partials/_head.html.erb
@@ -27,11 +27,15 @@
 <meta name="msapplication-TileColor" content="#71a32b">
 <meta name="theme-color" content="#ffffff">
 
-<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+<%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_pack_tag 'application' %>
 
 <%= javascript_tag do %>
   window._railsEnv = "<%= Rails.env %>"
+<% end %>
+
+<% if Rails.env.production? %>
+  <%= render 'partials/google_analytics' %>
 <% end %>
 
 <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
The users being registered where just those clicking on the button - no page views were registered. checkDuplicatedScript stops the analytics.js file being loaded twice