### PR TITLE
Remove 'width: 100%' for blockquotes

### DIFF
--- a/app/assets/stylesheets/utilities/_base.scss
+++ b/app/assets/stylesheets/utilities/_base.scss
@@ -194,7 +194,6 @@ blockquote {
   line-height: 1.7;
   padding-left: rem-calc(17);
   text-align: left;
-  width: 100%; // for ie11
 
   z-index: 1;
 


### PR DESCRIPTION
Closes [this issue](https://github.com/unepwcmc/pp-live-report/issues/108).

Removing the `width: 100%;` rule for blockquotes fixes this issue. There was a comment that suggested this rule was necessary for IE11. I gave it a quick look via BrowserStack's free trial and it looked okay to me, but I recommend that whoever reviews this checks this out on IE11.

