### PR TITLE
add hotjar and remove duplicate prod check on google analytics

### DIFF
--- a/app/views/partials/_head.html.erb
+++ b/app/views/partials/_head.html.erb
@@ -32,9 +32,8 @@
 <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 <%= stylesheet_pack_tag 'application' %>
 
-<% if Rails.env.production? %>
-  <%= render 'partials/google_analytics' %>
-<% end %>
+<%= render 'partials/google_analytics' %>
+<%= render 'partials/hotjar' %>
 
 <%= javascript_tag do %>
   window._railsEnv = "<%= Rails.env %>"

--- a/app/views/partials/_hotjar.html.erb
+++ b/app/views/partials/_hotjar.html.erb
@@ -1,0 +1,13 @@
+<!-- Hotjar Tracking Code for https://livereport.protectedplanet.net/ -->
+<% if Rails.env.production? %>
+  <script>
+      (function(h,o,t,j,a,r){
+          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+          h._hjSettings={hjid:2404823,hjsv:6};
+          a=o.getElementsByTagName('head')[0];
+          r=o.createElement('script');r.async=1;
+          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+          a.appendChild(r);
+      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+  </script>
+<% end %>


### PR DESCRIPTION
Adds hotjar only on production

Removes production check from head as this is already present in the google analytics partial. @stacytalbot let me know if you prefer the env checks not to be inside the partials. 